### PR TITLE
docs: add initial project roadmap referencing development workflow

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,36 @@
+# Roadmap for Goose TUI Calculator
+
+This roadmap highlights the key planned features and milestones for the Goose TUI Calculator project. It is aligned with the [development workflow guide](docs/development-workflow.md) to ensure transparency and maintainability.
+
+## Upcoming Milestones
+
+### Core Feature Implementation
+- Extend calculation engine for operator precedence and expression support
+- Implement repeated equals behavior
+- Add thorough unit and integration tests
+- Introduce --no-bell flag for audio feedback control
+
+### Visual Demo Coverage
+- Maintain comprehensive VHS tape scripts for all UI behaviors
+- Embed demo GIFs in PRs for easy visual review
+- Add demo enforcement in CI pipelines
+
+### Project Infrastructure
+- Add MIT License
+- Add CONTRIBUTING.md
+- Add CHANGELOG.md
+- Add .goreleaser.yml for automated releases
+- Set up Codecov for coverage reporting
+
+### User Experience Improvements
+- Theming support (light/dark mode)
+- Configurable precision and display formatting
+- History panel and extended calculator memory features
+
+## Contribution and Workflow
+
+Refer to the [Development Workflow](docs/development-workflow.md) for detailed contribution guidelines, demo creation, and PR standards.
+
+---
+
+*This roadmap is a living document and will evolve with the project's progress.*


### PR DESCRIPTION
This PR adds an initial roadmap for the Goose TUI Calculator project in . It highlights key upcoming features, demo coverage, infrastructure setup and UX improvements.\n\nThis roadmap aligns with our [development workflow](docs/development-workflow.md) to maintain contributor clarity and project health.\n\nReferences Issue #10.