### PR TITLE
Add prompt to guide Claude agent for issue-to-PR workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,14 +38,15 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # This prompt tells Claude what to do when working on an issue
+          prompt: |
+            When asked to work on an issue, please:
+            1. Create a new branch from the default branch, naming it according to the issue (e.g., issue-${{ github.event.issue.number }}-short-description).
+            2. Make the required changes/fixes as described in the issue.
+            3. Open a pull request from the new branch to the default branch, referencing the issue in the PR description.
+            4. Add a summary of changes in the PR description.
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: "--model glm-4.6"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,9 +44,14 @@ jobs:
           # This prompt tells Claude what to do when working on an issue
           prompt: |
             When asked to work on an issue, please:
-            1. Create a new branch from the default branch, naming it according to the issue (e.g., issue-${{ github.event.issue.number }}-short-description).
+            1. Create a new branch from the default branch, naming it according to the issue (e.g., issue-${{ github.event.issue.number }}-short-description). Use lowercase and hyphens for branch names.
             2. Make the required changes/fixes as described in the issue.
-            3. Open a pull request from the new branch to the default branch, referencing the issue in the PR description.
+            3. Open a pull request from the new branch to the default branch, referencing the issue in the PR description using "Fixes #${{ github.event.issue.number }}".
             4. Add a summary of changes in the PR description.
+
+            Error Handling:
+            - If you encounter test failures, fix them before creating the PR.
+            - If changes conflict with the target branch, resolve conflicts before pushing.
+            - If you cannot complete the task, add a comment to the issue explaining the blocker.
 
           claude_args: "--model glm-4.6"


### PR DESCRIPTION
This PR adds a prompt to the Claude Code workflow that instructs the agent to:
1. Create a new branch from the default branch when working on an issue
2. Make the required changes/fixes as described in the issue
3. Open a pull request from the new branch to the default branch
4. Reference the issue in the PR description with a summary of changes

This will enable automated issue-to-PR workflow when Claude is tagged in issues.