### PR TITLE
Fix workflow prompt template to use generic placeholders

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,9 +44,9 @@ jobs:
           # This prompt tells Claude what to do when working on an issue
           prompt: |
             When asked to work on an issue, please:
-            1. Create a new branch from the default branch, naming it according to the issue (e.g., issue-${{ github.event.issue.number }}-short-description). Use lowercase and hyphens for branch names.
+            1. Create a new branch from the default branch, naming it according to the issue (e.g., issue-123-short-description). Use lowercase and hyphens for branch names.
             2. Make the required changes/fixes as described in the issue.
-            3. Open a pull request from the new branch to the default branch, referencing the issue in the PR description using "Fixes #${{ github.event.issue.number }}".
+            3. Open a pull request from the new branch to the default branch, referencing the issue in the PR description using "Fixes #<issue-number>".
             4. Add a summary of changes in the PR description.
 
             Error Handling:


### PR DESCRIPTION
This PR fixes the Claude Code workflow prompt template to use generic placeholders instead of GitHub Actions template variables.

## Problem
The workflow prompt contained `${{ github.event.issue.number }}` which gets evaluated at YAML parse time, not runtime. This caused the prompt to have literal resolved values from when the workflow file was parsed.

## Solution
Replace with generic placeholders:
- `issue-${{ github.event.issue.number }}-short-description` → `issue-123-short-description`
- `Fixes #${{ github.event.issue.number }}` → `Fixes #<issue-number>`

Claude will infer the actual issue number from the context when it runs, so these generic examples are clearer and don't cause confusion.